### PR TITLE
Add ability to ignore Python specific versions in `versions.cfg`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .coverage
+.venv/
 *.pyc
 dist/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 1.0 (unreleased)
 
-- Nothing changed, yet.
+- Add ability to ignore Python specific versions in `versions.cfg`.
 
 ## 0.9 (2024-01-19)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"
 cov-report = [
   "- coverage combine",
-  "coverage report",
   "coverage html",
+  "coverage report",
 ]
 cov = [
   "test-cov",
@@ -88,3 +88,4 @@ fail_under = 100
 # N802: Function name {name} should be lowercase
 # T201: `print` found
 ignore = ["N802", "T201"]
+line-length = 80

--- a/src/vereqsyn/__about__.py
+++ b/src/vereqsyn/__about__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-present Michael Howitz <m.howitz@minddistrict.com>
+# SPDX-FileCopyrightText: 2024-present M. Howitz <m.howitz@minddistrict.com>
 #
 # SPDX-License-Identifier: MIT
 __version__ = "1.0"

--- a/src/vereqsyn/__init__.py
+++ b/src/vereqsyn/__init__.py
@@ -35,7 +35,9 @@ class VersionsCfgRequirementsTxtSync:
     version_cfg: str | None = None
 
     def __post_init__(self):
-        self.r_txt = RequirementsTxt(pathlib.Path(self.requirements_txt).resolve())
+        self.r_txt = RequirementsTxt(
+            pathlib.Path(self.requirements_txt).resolve()
+        )
         self.v_cfg = VersionCfg(pathlib.Path(self.version_cfg).resolve())
 
     @cleanup
@@ -187,7 +189,17 @@ class ConfigFile:
             if self.exhausted:
                 raise EOFError
         match = self.LINE_MATCHER.match(self.current_line)
-        package, version = match.groups()
+        try:
+            package, version = match.groups()
+        except AttributeError:
+            if self.current_line.startswith("[versions:python"):
+                error = EOFError
+            else:
+                error = SyntaxError(
+                    f"Cannot parse: {self.path}:{self.line_pointer+1}"
+                    f" {self.current_line}"
+                )
+            raise error from None
         return package.strip(), parse(version)
 
 

--- a/src/vereqsyn/__main__.py
+++ b/src/vereqsyn/__main__.py
@@ -9,11 +9,17 @@ def main(argv=None):
         "%(prog)s <versions.cfg> <requirements.txt>",
         "Bi-directional versions.cfg <-> requirements.txt synchronization",
     )
-    parser.add_argument("versions_cfg", action="store", help="path to versions.cfg")
-    parser.add_argument("requirements_txt", action="store", help="path to requirements.txt")
+    parser.add_argument(
+        "versions_cfg", action="store", help="path to versions.cfg"
+    )
+    parser.add_argument(
+        "requirements_txt", action="store", help="path to requirements.txt"
+    )
 
     args = parser.parse_args(argv)
-    command = vereqsyn.VersionsCfgRequirementsTxtSync(args.requirements_txt, args.versions_cfg)
+    command = vereqsyn.VersionsCfgRequirementsTxtSync(
+        args.requirements_txt, args.versions_cfg
+    )
     command.update()
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present Michael Howitz <m.howitz@minddistrict.com>
+# SPDX-FileCopyrightText: 2024-present M. Howitz <m.howitz@minddistrict.com>
 #
 # SPDX-License-Identifier: MIT

--- a/tests/fixtures/r-broken.txt
+++ b/tests/fixtures/r-broken.txt
@@ -1,0 +1,7 @@
+
+Babel==2.9.1
+Django==4.0.1
+# This file is in sync with v1.cfg
+Faker==11.3.0
+
+This file is broken because it contains this line which is neither a comment nor empty not a version pin.

--- a/tests/fixtures/v4.cfg
+++ b/tests/fixtures/v4.cfg
@@ -1,0 +1,13 @@
+[buildout]
+allow-picked-versions = false
+show-picked-versions = true
+
+[versions]
+Babel = 2.9.1
+Django = 4.0.2
+Faker = 11.3.0
+Genshi = 0.7.5
+
+# The following lines are allowed but get ignored:
+[versions:python37]
+Django = 3.0

--- a/tests/test_vereqsyn.py
+++ b/tests/test_vereqsyn.py
@@ -2,7 +2,7 @@ import pathlib
 
 import pytest
 
-from vereqsyn import ConfigFile, VersionsCfgRequirementsTxtSync
+from vereqsyn import ConfigFile, RequirementsTxt, VersionsCfgRequirementsTxtSync
 
 from .testing import tmp_copy
 
@@ -19,10 +19,14 @@ def test_VersionCfg_RequirementsTxt_Sync___sync__1(fixtures, tmp_path):
 
 def test_VersionCfg_RequirementsTxt_Sync___sync__2(fixtures):
     """It raises an exception if the package names are out of order."""
-    component = VersionsCfgRequirementsTxtSync(fixtures / "r1.txt", fixtures / "v2.cfg")
+    component = VersionsCfgRequirementsTxtSync(
+        fixtures / "r1.txt", fixtures / "v2.cfg"
+    )
     with pytest.raises(ReferenceError) as err:
         component._sync()  # noqa: SLF001 Private member accessed
-    assert str(err.value).startswith("Package entries out of order: Faker != FactoryBoy. Please recreate")
+    assert str(err.value).startswith(
+        "Package entries out of order: Faker != FactoryBoy. Please recreate"
+    )
 
 
 def test_VersionCfg_RequirementsTxt_Sync___recreate__1(fixtures, tmp_path):
@@ -37,7 +41,9 @@ def test_VersionCfg_RequirementsTxt_Sync___recreate__1(fixtures, tmp_path):
 
 def test_VersionCfg_RequirementsTxt_Sync__in_sync__1(fixtures):
     """It returns `True` if config files are in sync."""
-    component = VersionsCfgRequirementsTxtSync(requirements_txt=fixtures / "r1.txt", version_cfg=fixtures / "v1.cfg")
+    component = VersionsCfgRequirementsTxtSync(
+        requirements_txt=fixtures / "r1.txt", version_cfg=fixtures / "v1.cfg"
+    )
     assert component.in_sync()
 
 
@@ -52,15 +58,30 @@ def test_VersionCfg_RequirementsTxt_Sync__in_sync__1(fixtures):
 )
 def test_VersionCfg_RequirementsTxt_Sync__in_sync__2(fixtures, r_name, v_name):
     """It returns `False` if config files are out of sync."""
-    component = VersionsCfgRequirementsTxtSync(requirements_txt=fixtures / r_name, version_cfg=fixtures / v_name)
+    component = VersionsCfgRequirementsTxtSync(
+        requirements_txt=fixtures / r_name, version_cfg=fixtures / v_name
+    )
     assert not component.in_sync()
+
+
+def test_VersionCfg_RequirementsTxt_Sync__in_sync__3(fixtures):
+    """It returns `True` if config files are in sync.
+
+    Even if they contain Python a version specific section.
+    """
+    component = VersionsCfgRequirementsTxtSync(
+        requirements_txt=fixtures / "r3.txt", version_cfg=fixtures / "v4.cfg"
+    )
+    assert component.in_sync()
 
 
 def test_VersionCfg_RequirementsTxt_Sync__update__1(fixtures, tmp_path):
     """It updates out of sync files."""
     r3 = tmp_copy(tmp_path, fixtures / "r3.txt")
     v3 = tmp_copy(tmp_path, fixtures / "v3.cfg")
-    component = VersionsCfgRequirementsTxtSync(requirements_txt=r3, version_cfg=v3)
+    component = VersionsCfgRequirementsTxtSync(
+        requirements_txt=r3, version_cfg=v3
+    )
     assert not component.in_sync()
     component.update()
     assert component.in_sync()
@@ -70,7 +91,9 @@ def test_VersionCfg_RequirementsTxt_Sync__update__2(fixtures, tmp_path):
     """It recreates requirements.txt if packages are out of order."""
     r1 = tmp_copy(tmp_path, fixtures / "r1.txt")
     v2 = tmp_copy(tmp_path, fixtures / "v2.cfg")
-    component = VersionsCfgRequirementsTxtSync(requirements_txt=r1, version_cfg=v2)
+    component = VersionsCfgRequirementsTxtSync(
+        requirements_txt=r1, version_cfg=v2
+    )
     assert not component.in_sync()
     component.update()
     assert component.in_sync()
@@ -81,3 +104,13 @@ def test_ConfigFile____post_init____1():
     with pytest.raises(FileNotFoundError) as e:
         ConfigFile(pathlib.Path("i-do-not-exist.cfg"))
     assert e.match(r"PosixPath\('i-do-not-exist.cfg'\) does not exist\.")
+
+
+def test_RequirementsTxt___parse_current_line__1(fixtures):
+    """It raises a SyntaxError if it cannot parse a line."""
+    r = RequirementsTxt(fixtures / "r-broken.txt")
+    with pytest.raises(SyntaxError) as e:
+        list(r)
+    assert e.match(
+        "Cannot parse: .*/r-broken.txt:7 This file is broken because.*"
+    )

--- a/tests/test_vereqsyn.py
+++ b/tests/test_vereqsyn.py
@@ -67,7 +67,7 @@ def test_VersionCfg_RequirementsTxt_Sync__in_sync__2(fixtures, r_name, v_name):
 def test_VersionCfg_RequirementsTxt_Sync__in_sync__3(fixtures):
     """It returns `True` if config files are in sync.
 
-    Even if they contain Python a version specific section.
+    Even if the versions.cfg contains Python a version specific section.
     """
     component = VersionsCfgRequirementsTxtSync(
         requirements_txt=fixtures / "r3.txt", version_cfg=fixtures / "v4.cfg"


### PR DESCRIPTION
+ make lines no longer than 80 chars.